### PR TITLE
Add SiteRacer under Tools → Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ TBD
 - [WebPageTest.org](https://www.webpagetest.org/) — Web Performance and Optimization Test.
 - [RequestMap](https://requestmap.webperf.tools/) — Rapidly identify what third-parties are on your site, where your transmitted bytes are coming from and how slow your domains are!
 - [Capo](https://chrome.google.com/webstore/detail/capo-get-your-%3Chead%3E-in-o/ohabpnaccigjhkkebjofhpmebofgpbeb) — Visualize the optimal ordering of <head> elements on any web page.
+- [SiteRacer](https://siteracer.com/) — Side-by-side website speed comparison; benchmarks TTFB and page size against up to three competitor sites and detects hosting, CDN, and caching.
 
 ### Bundle Analyzers
 


### PR DESCRIPTION
Adds [SiteRacer](https://siteracer.com/) to the **Analyzers** section, alongside WebPageTest and PageSpeed Insights. It is a free, no-signup analyzer that compares a site's TTFB and page size side-by-side against up to three competitors and detects the hosting/CDN/caching stack. Matched the section's em-dash entry style. Single-line addition.