### PR TITLE
Add Screpy to Web Performance Analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ TBD
 - [Lighthouse](https://github.com/GoogleChrome/lighthouse) — Automated auditing, performance metrics, and best practices for the web.
 - [PageSpeed Insights](https://pagespeed.web.dev/) — Lighthouse as a Service.
 - [WebPageTest.org](https://www.webpagetest.org/) — Web Performance and Optimization Test.
+- [Screpy](https://screpy.com/) — Monitors Core Web Vitals, page speed, uptime, and technical SEO issues.
 - [RequestMap](https://requestmap.webperf.tools/) — Rapidly identify what third-parties are on your site, where your transmitted bytes are coming from and how slow your domains are!
 - [Capo](https://chrome.google.com/webstore/detail/capo-get-your-%3Chead%3E-in-o/ohabpnaccigjhkkebjofhpmebofgpbeb) — Visualize the optimal ordering of <head> elements on any web page.
 


### PR DESCRIPTION
## Summary

Adds [Screpy](https://screpy.com/) to the Web Performance Analyzers section.

## Why

The entry describes the relevant website monitoring capabilities: Core Web Vitals, page speed, uptime, and technical SEO checks.

## Validation

- Confirmed the official link is publicly reachable.
- Confirmed this list does not already contain Screpy.
- Checked the diff: one README-only addition (seven lines where the repository's entry format requires feature bullets).

Affiliation: submitted on behalf of Screpy.
