### PR TITLE
Add Nutilz Image Compressor to Image Optimization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ TBD
 - [ImageOptim CLI](https://github.com/JamieMason/ImageOptim-CLI) — Make optimisation of images part of your automated build process.
 - [ImageOptim](https://imageoptim.com/mac) — ImageOptim optimizes images without losing quality or any metadata.
 - [SVGO](https://github.com/svg/svgo) — Node.js tool for optimizing SVG files.
+- [Nutilz Image Compressor](https://nutilz.com/image-compressor) — Free browser-based tool to reduce JPG, PNG and WebP file size before upload, no signup or install required.
 
 ### Resources
 


### PR DESCRIPTION
Adds [nutilz.com/image-compressor](https://nutilz.com/image-compressor), a free browser-based tool that reduces JPG/PNG/WebP file size before upload -- useful alongside Squoosh/ImageOptim for the same image-optimization workflow this list already covers. No signup, no install, works entirely from the page like the other tools in this section.